### PR TITLE
Add compat field for PyPlot in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ FLOWMath = "6cb5d3fb-0fe8-4cc2-bd89-9fe0b19a99d3"
 
 [compat]
 julia = "1"
-PyPlot = "<= 2.11.1"
+PyPlot = "< 2.11.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ FLOWMath = "6cb5d3fb-0fe8-4cc2-bd89-9fe0b19a99d3"
 
 [compat]
 julia = "1"
+PyPlot = "2.11.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ FLOWMath = "6cb5d3fb-0fe8-4cc2-bd89-9fe0b19a99d3"
 
 [compat]
 julia = "1"
-PyPlot = "2.11.1"
+PyPlot = "<= 2.11.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This PR resolves issue #2 with FLOWNoise being incompatible with PyPlot v2.11.2.
It adds an entry for PyPlot in the compat field in `Project.toml`